### PR TITLE
Ограничить разбор DoH-ответа секцией Answer

### DIFF
--- a/crates/wrtg/src/cf_proxy_doh.rs
+++ b/crates/wrtg/src/cf_proxy_doh.rs
@@ -95,10 +95,17 @@ fn parse_doh_a_records(body: &[u8]) -> Vec<String> {
     let text = String::from_utf8_lossy(body);
     let mut out = Vec::new();
     // Only look inside the "Answer" array, then walk each `{…}` record. DoH
-    // answer records are flat objects, so splitting on `{` isolates them.
-    let Some((_, answer)) = text.split_once("\"Answer\"") else {
+    // answer records are flat objects, so splitting on `{` isolates them, and
+    // the first `]` after the opening `[` closes the array — bound the scan
+    // there so type-A records in a later "Authority" / "Additional" (glue)
+    // section can't leak an address that was never in the answer.
+    let Some((_, after)) = text.split_once("\"Answer\"") else {
         return out;
     };
+    let Some((_, array)) = after.split_once('[') else {
+        return out;
+    };
+    let answer = array.split(']').next().unwrap_or(array);
     for rec in answer.split('{').skip(1) {
         if !record_is_type_a(rec) {
             continue;
@@ -260,6 +267,17 @@ mod tests {
             {"name":"x.co.uk","type":16,"data":"v=spf1 -all"},
             {"name":"x.co.uk","type":1,"data":"104.21.75.42"}
         ]}"#;
+        let ips = parse_doh_a_records(json);
+        assert_eq!(ips, vec!["104.21.75.42".to_string()]);
+    }
+
+    #[test]
+    fn parse_doh_a_records_ignores_non_answer_sections() {
+        // A type-A record in the "Additional" (glue) section must not leak into
+        // the result: only the address inside the "Answer" array is returned.
+        let json = br#"{"Status":0,
+            "Answer":[{"name":"x.co.uk","type":1,"data":"104.21.75.42"}],
+            "Additional":[{"name":"ns1.example.","type":1,"data":"198.51.100.9"}]}"#;
         let ips = parse_doh_a_records(json);
         assert_eq!(ips, vec!["104.21.75.42".to_string()]);
     }


### PR DESCRIPTION
## Симптом

На резервном пути CF-proxy (`try_cf_proxy_domain`), когда прямой дозвон по имени хоста домена не удаётся, используется DoH-резолвер (`resolve_doh`). Он мог вернуть IP-адрес, которого **не было** в ответе на запрошенное имя. В результате соединение устанавливалось по «чужому» адресу, а TLS SNI/Host оставались прежними — итог: несовпадение сертификата (SNI/cert mismatch) и обрыв резервного соединения, хотя валидный ответ формально был получен.

## Первопричина

Функция `parse_doh_a_records` (`crates/wrtg/src/cf_proxy_doh.rs`) в комментарии заявляла, что просматривает только массив `"Answer"`, но фактически сканировала **все** записи до конца тела ответа:

```rust
let Some((_, answer)) = text.split_once("\"Answer\"") else { return out; };
for rec in answer.split('{').skip(1) { ... }
```

После `split_once("\"Answer\"")` переменная `answer` содержала весь остаток JSON, включая секции `"Authority"` и `"Additional"` (glue). Любая type-A запись в этих секциях попадала в список кандидатов. Если в самом `Answer` не было пригодного IPv4, `pick_preferred_ip` мог выбрать glue-адрес из `Additional` — адрес, который никогда не был ответом для запрошенного имени.

## Исправление

Разбор ограничен содержимым массива `Answer`: берём часть после открывающей `[` и обрезаем по первой `]`, закрывающей массив. Записи из последующих секций больше не сканируются.

```rust
let Some((_, after)) = text.split_once("\"Answer\"") else { return out; };
let Some((_, array)) = after.split_once('[') else { return out; };
let answer = array.split(']').next().unwrap_or(array);
for rec in answer.split('{').skip(1) { ... }
```

## Изменённые файлы

- `crates/wrtg/src/cf_proxy_doh.rs`
  - `parse_doh_a_records` (≈ строки 94–108): ограничение области разбора массивом `Answer`.
  - Новый тест `parse_doh_a_records_ignores_non_answer_sections` (≈ строки 274–284).

## Как проверено

Добавлен тест, который **падает до** исправления и **проходит после**: ответ содержит валидную A-запись в `Answer` (`104.21.75.42`) и постороннюю A-запись в `Additional` (`198.51.100.9`); ожидается только адрес из `Answer`.

- До фикса: `parse_doh_a_records` возвращает `["104.21.75.42", "198.51.100.9"]` → тест падает.
- После фикса: возвращает `["104.21.75.42"]` → тест проходит.

Проверки:
- `cargo build` — OK (exit 0)
- `cargo test --lib` — OK (75 passed, 0 failed), включая новый тест
- `cargo clippy --all-targets` — OK (exit 0)
- `cargo fmt --check` — OK (exit 0)