### PR TITLE
Объединённый PR: фикс DoH + bump cargo/actions + миграция rand 0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -65,7 +65,7 @@ jobs:
             out: wrtg-linux-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set version
         run: echo "VERSION=$(cat VERSION)" >> "$GITHUB_ENV"
@@ -94,7 +94,7 @@ jobs:
           chmod +x "dist/${{ matrix.out }}"
           file "dist/${{ matrix.out }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.out }}
           path: dist/${{ matrix.out }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -58,7 +58,7 @@ jobs:
             out: wrtg-linux-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check VERSION matches tag
         run: |
@@ -93,7 +93,7 @@ jobs:
           chmod +x "dist/${{ matrix.out }}"
           file "dist/${{ matrix.out }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.out }}
           path: dist/${{ matrix.out }}
@@ -109,9 +109,9 @@ jobs:
       # is unset the Gitea step is skipped and only the GitHub release is created.
       GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -130,7 +130,7 @@ jobs:
           cd dist
           sha256sum wrtg-linux-* wrtg-openwrt.tar.gz > SHA256SUMS
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,13 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -141,12 +141,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "crypto-common 0.1.7",
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -172,13 +184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -187,16 +196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -210,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -256,7 +255,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -295,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -309,16 +308,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -340,6 +329,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -359,11 +349,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -476,15 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,33 +491,20 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -583,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -645,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -663,16 +631,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -733,7 +691,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -782,12 +740,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -907,30 +859,10 @@ dependencies = [
  "rand",
  "rustls",
  "sha1",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tokio-rustls",
  "webpki-roots",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/wrtg/Cargo.toml
+++ b/crates/wrtg/Cargo.toml
@@ -10,14 +10,14 @@ name = "wrtg"
 path = "src/main.rs"
 
 [dependencies]
-aes = "0.8"
+aes = "0.9"
 base64 = "0.22"
 bytes = "1"
-ctr = "0.9"
+ctr = "0.10"
 env_logger = "0.11"
 log = "0.4"
-rand = "0.8"
-socket2 = { version = "0.5", features = ["all"] }
+rand = "0.10"
+socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }

--- a/crates/wrtg/src/cf_proxy_doh.rs
+++ b/crates/wrtg/src/cf_proxy_doh.rs
@@ -95,10 +95,17 @@ fn parse_doh_a_records(body: &[u8]) -> Vec<String> {
     let text = String::from_utf8_lossy(body);
     let mut out = Vec::new();
     // Only look inside the "Answer" array, then walk each `{…}` record. DoH
-    // answer records are flat objects, so splitting on `{` isolates them.
-    let Some((_, answer)) = text.split_once("\"Answer\"") else {
+    // answer records are flat objects, so splitting on `{` isolates them, and
+    // the first `]` after the opening `[` closes the array — bound the scan
+    // there so type-A records in a later "Authority" / "Additional" (glue)
+    // section can't leak an address that was never in the answer.
+    let Some((_, after)) = text.split_once("\"Answer\"") else {
         return out;
     };
+    let Some((_, array)) = after.split_once('[') else {
+        return out;
+    };
+    let answer = array.split(']').next().unwrap_or(array);
     for rec in answer.split('{').skip(1) {
         if !record_is_type_a(rec) {
             continue;
@@ -260,6 +267,17 @@ mod tests {
             {"name":"x.co.uk","type":16,"data":"v=spf1 -all"},
             {"name":"x.co.uk","type":1,"data":"104.21.75.42"}
         ]}"#;
+        let ips = parse_doh_a_records(json);
+        assert_eq!(ips, vec!["104.21.75.42".to_string()]);
+    }
+
+    #[test]
+    fn parse_doh_a_records_ignores_non_answer_sections() {
+        // A type-A record in the "Additional" (glue) section must not leak into
+        // the result: only the address inside the "Answer" array is returned.
+        let json = br#"{"Status":0,
+            "Answer":[{"name":"x.co.uk","type":1,"data":"104.21.75.42"}],
+            "Additional":[{"name":"ns1.example.","type":1,"data":"198.51.100.9"}]}"#;
         let ips = parse_doh_a_records(json);
         assert_eq!(ips, vec!["104.21.75.42".to_string()]);
     }

--- a/crates/wrtg/src/cf_proxy_domains.rs
+++ b/crates/wrtg/src/cf_proxy_domains.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 
@@ -146,8 +146,8 @@ pub fn apply_proxy_domains(domains: Vec<String>) {
 }
 
 pub async fn fetch_cfproxy_domains() -> Vec<String> {
-    let cache_bust: String = rand::thread_rng()
-        .sample_iter(rand::distributions::Alphanumeric)
+    let cache_bust: String = rand::rng()
+        .sample_iter(rand::distr::Alphanumeric)
         .take(7)
         .map(char::from)
         .collect();

--- a/crates/wrtg/src/mtproto.rs
+++ b/crates/wrtg/src/mtproto.rs
@@ -3,7 +3,7 @@ use std::sync::{OnceLock, RwLock};
 
 use aes::Aes256;
 use ctr::cipher::{KeyIvInit, StreamCipher};
-use rand::RngCore;
+use rand::Rng;
 
 type Aes256Ctr = ctr::Ctr128BE<Aes256>;
 
@@ -401,7 +401,7 @@ pub fn parse_direct_handshake(handshake: &[u8]) -> Result<HandshakeInfo, String>
 }
 
 pub fn generate_relay_init(proto_tag: [u8; 4], dc_idx: i16) -> Result<Vec<u8>, String> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     loop {
         let mut rnd = vec![0u8; HANDSHAKE_LEN];
         rng.fill_bytes(&mut rnd);

--- a/crates/wrtg/src/ws.rs
+++ b/crates/wrtg/src/ws.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use crate::mtproto::MAX_WS_PAYLOAD;
 use crate::sockopt::tune_tcp;
 use base64::{engine::general_purpose::STANDARD, Engine};
-use rand::RngCore;
+use rand::Rng;
 use rustls::pki_types::ServerName;
 use sha1::{Digest, Sha1};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -157,7 +157,7 @@ async fn connect_ws_inner(
 
     let ws_key = {
         let mut key = [0u8; 16];
-        rand::thread_rng().fill_bytes(&mut key);
+        rand::rng().fill_bytes(&mut key);
         STANDARD.encode(key)
     };
 
@@ -590,7 +590,7 @@ fn build_ws_frame(opcode: u8, data: &[u8], mask: bool) -> Vec<u8> {
         return hdr;
     }
     let mut mask_key = [0u8; 4];
-    rand::thread_rng().fill_bytes(&mut mask_key);
+    rand::rng().fill_bytes(&mut mask_key);
     let masked = xor_mask_owned(data, &mask_key);
     let mut hdr = ws_header_masked(fb, length, &mask_key);
     hdr.extend_from_slice(&masked);


### PR DESCRIPTION
Объединяет три открытых PR в один. Все изменения собраны поверх актуального `main`, проект собирается и проходит тесты.

## Что входит

### 1. Ограничение разбора DoH секцией `Answer` (было #4)
- **Баг:** `parse_doh_a_records` в `crates/wrtg/src/cf_proxy_doh.rs` заявляла, что сканирует только массив `"Answer"`, но фактически шла до конца тела ответа, включая секции `"Authority"`/`"Additional"` (glue-записи).
- **Первопричина:** после `split_once("\"Answer\"")` переменная содержала весь остаток JSON. Любая type-A запись из glue-секций попадала в кандидаты, и `pick_preferred_ip` мог выбрать IP, который никогда не был ответом на запрос.
- **Сценарий отказа:** на fallback-пути CF-прокси `resolve_doh` возвращал «чужой» IP → подключение шло на неверный адрес, а TLS SNI/Host оставались исходным хостнеймом → mismatch сертификата → сломанный fallback при формально валидном DoH-ответе.
- **Фикс:** скан ограничен массивом `Answer` (срез после `[`, обрезка по первой `]`). Добавлен тест `parse_doh_a_records_ignores_non_answer_sections`.

### 2. Обновление Cargo-зависимостей (было #3)
Bump группы cargo: `aes` 0.8→0.9, `bytes` 1.12.0→1.12.1, `ctr` 0.9→0.10, `rand` 0.8→0.10, `socket2` 0.5→0.6, `rustls` 0.23.41→0.23.42.

### 3. Обновление GitHub Actions (было #1)
Bump группы actions: `actions/checkout` v4→v7, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4→v8, `softprops/action-gh-release` v2→v3.

### 4. Миграция кода под rand 0.10 (новое, требуется для сборки)
Мажорный bump `rand` 0.8→0.10 ломает API. Адаптировано:
- `rand::thread_rng()` → `rand::rng()` (в `mtproto.rs`, `ws.rs`, `cf_proxy_domains.rs`);
- `use rand::RngCore` → `use rand::Rng` (для `fill_bytes`);
- `use rand::Rng` → `use rand::RngExt` и `rand::distributions::Alphanumeric` → `rand::distr::Alphanumeric` (в `cf_proxy_domains.rs`).

Без этих правок обновление `rand` из PR #3 не компилируется.

## Проверка
- `cargo build` — OK, без предупреждений
- `cargo test --lib` — 75 passed / 0 failed (включая новый тест DoH)
- `cargo clippy --all-targets` — OK
- `cargo fmt --check` — OK

## После слияния
PR #1, #3 и #4 можно закрыть — все их изменения вошли сюда.
